### PR TITLE
Arregla enlace "Abrir en Google Maps"

### DIFF
--- a/httpdocs/assets/javascript/components/page-mapa.js
+++ b/httpdocs/assets/javascript/components/page-mapa.js
@@ -127,7 +127,7 @@ customElements.define(
         </div>
         <a
           slot="google_link"
-          href="${place.google.maps}" rel="noreferrer" target="_blank">
+          href="${place.google.link}" rel="noreferrer" target="_blank">
           Abrir en Google Maps
         </a>
 


### PR DESCRIPTION
El enlace "Abrir en Google Maps" apuntaba a una dirección incorrecta.