### PR TITLE
Corregir error de pérdida de un día en las fechas en equipos que se encuentren al oeste de la zona horaria UTC

### DIFF
--- a/httpdocs/assets/javascript/components/page-biblioteca.js
+++ b/httpdocs/assets/javascript/components/page-biblioteca.js
@@ -511,6 +511,7 @@ customElements.define(
         year: 'numeric',
         month: 'long',
         day: 'numeric',
+        timeZone: 'UTC', //en ubicaciones al oeste del UTC sin esta opción la fecha aparece un día antes de la registrada
       }
 
       const item = this.visible.find((item) => item.id === id)
@@ -623,6 +624,7 @@ customElements.define(
         year: 'numeric',
         month: grid ? '2-digit' : 'long',
         day: grid ? '2-digit' : 'numeric',
+        timeZone: 'UTC', //en ubicaciones al oeste del UTC sin esta opción la fecha aparece un día antes de la registrada
       }
       const items = []
 

--- a/httpdocs/assets/javascript/components/page-entramado.js
+++ b/httpdocs/assets/javascript/components/page-entramado.js
@@ -339,6 +339,7 @@ customElements.define(
         year: 'numeric',
         month: 'long',
         day: 'numeric',
+        timeZone: 'UTC', //para que equipos al oeste de la zona horaria UTC no quiten un día a la fecha, ver https://codefordev.com/discuss/6361936491/tolocaledatestring-is-subtracting-a-day
       }
       if (item.birthdate && item.deathdate) {
         const birth = new Date(item.birthdate)


### PR DESCRIPTION
Se agregó la opción de siempre poner la fecha en zona horaria UTC para evitar que la fecha en equipos ubicado al oeste del meridiano cero quiten 1 día.

Para esto solo se agregó en las constantes `dateFormat` la opción `timeZone: 'UTC',`

Ver https://dev.to/zachgoll/a-complete-guide-to-javascript-dates-and-why-your-date-is-off-by-1-day-fi1
Ver https://codefordev.com/discuss/6361936491/tolocaledatestring-is-subtracting-a-day 